### PR TITLE
Chore/a1 odt 677 add servicemonitor

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
+version: 0.1.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: maintenance-dashboard-source
+  namespace: monitoring
+spec:
+  endpoints:
+  - path: /metrics
+    port: http
+    scheme: http
+  jobLabel: maintenance-dashboard-source
+  namespaceSelector:
+    matchNames:
+    - maintenance-dashboard-app
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: maintenance-dasboard-app


### PR DESCRIPTION
The servicemonitor resource will tell the prometheus server to scrape the prometheus endpoint deployed with the maintenance dashboard app.