### PR TITLE
Feat/scan svc resources as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The purpose of this application is to gather version information about the appli
 
 1. The application is collecting information from the cluster the following way:
    - Gets the `kubelet` version from each node
-   - Searches for every service in every namespace that is labeled with `maintenance/scan=true`. The version is extracted from the value of the `app.kubernetes.io/version` label. The version format has to follow [SemVer](https://semver.org/) rules. It also reads the value of the `maintenance/releasename` annotation to match the name with the one in [NewReleases.io](newreleases.io).
+   - Searches for every service, deployment, statefulset, daemonset in every namespace that is labeled with `maintenance/scan=true`. The version is extracted from the value of the `app.kubernetes.io/version` label. The version format has to follow [SemVer](https://semver.org/) rules. It also reads the value of the `maintenance/releasename` annotation to match the name with the one in [NewReleases.io](newreleases.io).
 2. [NewReleases.io](newreleases.io) is queried and the latest versinos are pulled. The application then finds the latest non-prerelease version.
 3. The results are exposed at the `/metrics` endpoint as the application is listening on the `:2112` port within the cluster.
 
@@ -18,24 +18,21 @@ See in the [INSTALL.md](INSTALL.md).
 
 ``` sh
 
-# 1. Select a k8s resource that has a kind of `service`.
+# Example for a service resource.
+# 1. Select a k8s resource that has a kind of `service`, `deployment`, `statefulset` or `daemonset`.
 
-# 2. Add the following label to this service: `maintenance/scan=true`.
+# 2. Add the following label to this resource: `maintenance/scan=true`.
 kubectl label svc -n [NAMESPACE] [SERVICE_NAME] maintenance/scan=true
 
-# 3. Check if this recommended label exists on the service: `app.kubernetes.io/version`.
+# 3. Check if this recommended label exists on the resource: `app.kubernetes.io/version`.
 kubectl get svc -n [NAMESPACE] [SERVICE_NAME] -o jsonpath="{.metadata.labels.app\.kubernetes\.io/version}"
 
 # 4. If not, add it with the proper app version in `semver` format.
 kubectl label svc -n [NAMESPACE] [SERVICE_NAME] app.kubernetes.io/version=[SEMVER_VERSION]
 
-# 5. Annotate service with the key `maintenance/releasename` and the value from the name of the project found on NewReleases.io.
+# 5. Annotate resource with the key `maintenance/releasename` and the value from the name of the project found on NewReleases.io.
 kubectl annotate svc -n [NAMESPACE] [SERVICE_NAME] maintenance/releasename=[NEWRELEASES_PROJECT_NAME]
 
 ```
 
 When these labels and annotations are set, the maintenance dashboard will pick up and serve metrics about the application.
-
-## TODOs
-
-- Improve label and annotation process for components to scan in the cluster

--- a/charts/maintenance-dashboard/Chart.yaml
+++ b/charts/maintenance-dashboard/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.4
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.1"
+appVersion: "1.3.0"


### PR DESCRIPTION
This way the following resource types will be scanned in all namespaces:

- service
- deployment
- daemonset
- statefulset

Also updated the `README` accordingly.